### PR TITLE
Refactor rules scripting to use shared ScriptRef

### DIFF
--- a/src/rules/components/ScriptRef.js
+++ b/src/rules/components/ScriptRef.js
@@ -1,8 +1,0 @@
-// Spell.js
-// ECS Component: Learned spell
-import { defineComponent } from "../../lib/ecs-js/index.js";
-
-export const ScriptRef = defineComponent('ScriptRef', {
-  ref: null,   // string identifier or function name
-  params: {}   // shallow params object
-});

--- a/src/rules/components/index.js
+++ b/src/rules/components/index.js
@@ -25,6 +25,5 @@ export { EquipIntent } from './Intents/EquipIntent.js';
 export { Status } from './Status.js';
 export { Vitality } from './Vitality.js';
 export { Settings } from './Settings.js';
-export { ScriptRef } from './ScriptRef.js';
 export { UseIntent } from './Intents/UseIntent.js';
 export { DungeonGeometry } from './DungeonGeometry.js';

--- a/src/rules/data/affixes.js
+++ b/src/rules/data/affixes.js
@@ -1,41 +1,71 @@
 // Affix definitions: triggers can be onBeforeHit, onHit, onDamaged, onKill, onEquip, onUnequip
-// passive(ctx) executed during derived stat recalculation.
+// Scripts are registered via the central scripting router.
 import { mulberry32, rngInt } from "../../lib/ecs-js/rng.js";
 import { ActiveEffects } from "../components/ActiveEffects.js";
-export const AFFIX_DEFS = {
-  // 20% chance to retaliate for 2 on successful hit (defender-side), shown in HUD for 3 turns
-  thorns1: { name:'Thorns I', slots:['armor'], triggers:['onHit'], script:(ctx)=>{
+import { registerScript, ScriptVerb } from "../scripting.js";
+
+const AFFIX_THORNS = "affix:thorns1";
+const AFFIX_VAMP = "affix:vamp1";
+const AFFIX_FIERCE = "affix:fierce";
+const AFFIX_GUARD = "affix:guard1";
+const AFFIX_LIFE = "affix:life1";
+
+registerScript(AFFIX_THORNS, {
+  [ScriptVerb.AffixOnHit]: (world, ctx) => {
     try {
-      const w = ctx && ctx.world;
       const attacker = (ctx && ctx.attacker) | 0;
       const defender = (ctx && ctx.defender) | 0;
-      const step = (w && w.step) | 0;
-      // Deterministic seed derived from world seed, step, participants, and a constant salt
-      const seed = ((w?.seed >>> 0) ^ ((step * 0x9e3779b9) >>> 0) ^ (attacker >>> 0) ^ ((defender << 16) >>> 0) ^ 0xc0ffee01) >>> 0;
+      const step = (world && world.step) | 0;
+      const seed = ((world?.seed >>> 0) ^ ((step * 0x9e3779b9) >>> 0) ^ (attacker >>> 0) ^ ((defender << 16) >>> 0) ^ 0xc0ffee01) >>> 0;
       const r = mulberry32(seed);
       const roll = rngInt(r, 1, 100);
       if (roll <= 20) {
-        // Apply retaliation damage to attacker
         ctx.retaliate(2);
-        // Display-only status for HUD/overlay this turn
         try {
-          const ae = w.get(defender, ActiveEffects);
+          const ae = world.get(defender, ActiveEffects);
           if (ae && Array.isArray(ae.effects)) {
-            ae.effects.push({ key: 'thorns', turnsLeft: 3, potency: 1 });
+            ae.effects.push({ key: "thorns", turnsLeft: 3, potency: 1 });
           } else {
-            w.add(defender, ActiveEffects, { effects: [{ key: 'thorns', turnsLeft: 3, potency: 1 }] });
+            world.add(defender, ActiveEffects, { effects: [{ key: "thorns", turnsLeft: 3, potency: 1 }] });
           }
         } catch {}
       }
     } catch {
-      // Fail-safe: if rng fails for any reason, default to proc (keeps gameplay feedback), but don't crash
       ctx.retaliate(2);
     }
-  }, weight:30 },
-  vamp1:   { name:'Vampiric I', slots:['weapon'], triggers:['onHit'], script:(ctx)=>{ ctx.healAttacker(Math.max(1, Math.floor(ctx.damage/3))); }, weight:20 },
-  fierce:  { name:'Fierce', slots:['weapon'], triggers:['onBeforeHit'], script:(ctx)=>{ ctx.damage += 1; }, weight:25 },
-  guard1:  { name:'Guarded', slots:['armor'], passive:(ctx)=>{ ctx.addBonus('defense',1); }, triggers:[], weight:25 },
-  life1:   { name:'Healthy', slots:['armor','ring'], passive:(ctx)=>{ ctx.addBonus('maxHp',5); }, triggers:[], weight:22 }
+  },
+});
+
+registerScript(AFFIX_VAMP, {
+  [ScriptVerb.AffixOnHit]: (_world, ctx) => {
+    ctx.healAttacker(Math.max(1, Math.floor(ctx.damage / 3)));
+  },
+});
+
+registerScript(AFFIX_FIERCE, {
+  [ScriptVerb.AffixOnBeforeHit]: (_world, ctx) => {
+    ctx.damage += 1;
+  },
+});
+
+registerScript(AFFIX_GUARD, {
+  [ScriptVerb.AffixPassive]: (_world, ctx) => {
+    ctx.addBonus("defense", 1);
+  },
+});
+
+registerScript(AFFIX_LIFE, {
+  [ScriptVerb.AffixPassive]: (_world, ctx) => {
+    ctx.addBonus("maxHp", 5);
+  },
+});
+
+export const AFFIX_DEFS = {
+  thorns1: { name: "Thorns I", slots: ["armor"], triggers: ["onHit"], script: AFFIX_THORNS, weight: 30 },
+  vamp1: { name: "Vampiric I", slots: ["weapon"], triggers: ["onHit"], script: AFFIX_VAMP, weight: 20 },
+  fierce: { name: "Fierce", slots: ["weapon"], triggers: ["onBeforeHit"], script: AFFIX_FIERCE, weight: 25 },
+  guard1: { name: "Guarded", slots: ["armor"], passive: AFFIX_GUARD, triggers: [], weight: 25 },
+  life1: { name: "Healthy", slots: ["armor", "ring"], passive: AFFIX_LIFE, triggers: [], weight: 22 },
 };
 
 export function listAffixes() { return Object.entries(AFFIX_DEFS).map(([id, rec]) => ({ id, ...rec })); }

--- a/src/rules/data/equipmentLoader.js
+++ b/src/rules/data/equipmentLoader.js
@@ -7,7 +7,7 @@ import { EQUIP_DEFS, getEquipmentDef } from './equipment.js';
 import { AFFIX_DEFS } from './affixes.js';
 import { ItemInfo } from '../components/ItemInfo.js';
 import { NamedIdentity } from '../components/NamedIdentity.js';
-import { ScriptRef } from '../components/ScriptRef.js';
+import { ScriptRef } from '../../lib/ecs-js/index.js';
 
 /**
  * listEquipment()
@@ -43,8 +43,8 @@ export function buildEquipmentItem(world, equipId, opts = {}) {
   };
   world.add(id, ItemInfo, info);
   // Attach script reference when supplied (for onEquip/onHit, etc.)
-  if (typeof base.script === 'function') {
-    world.add(id, ScriptRef, { ref: base.script, params: { from: base.id } });
+  if (typeof base.script === 'string' && base.script) {
+    world.add(id, ScriptRef, { key: base.script, params: { from: base.id } });
   }
   return id;
 }

--- a/src/rules/data/validate.js
+++ b/src/rules/data/validate.js
@@ -26,8 +26,8 @@ export function validateAffixes(AFFIX_DEFS) {
     if (typeof rec.name !== 'string' || !rec.name) throw new Error(`affix ${id}: name required`);
     if (!Array.isArray(rec.slots) || rec.slots.length === 0) throw new Error(`affix ${id}: slots required`);
     if (!Array.isArray(rec.triggers)) throw new Error(`affix ${id}: triggers must be array`);
-    if (rec.script && typeof rec.script !== 'function') throw new Error(`affix ${id}: script must be function`);
-    if (rec.passive && typeof rec.passive !== 'function') throw new Error(`affix ${id}: passive must be function`);
+    if (rec.script && typeof rec.script !== 'string') throw new Error(`affix ${id}: script must be string`);
+    if (rec.passive && typeof rec.passive !== 'string') throw new Error(`affix ${id}: passive must be string`);
   }
   return true;
 }

--- a/src/rules/scripting.js
+++ b/src/rules/scripting.js
@@ -1,0 +1,121 @@
+import { ScriptRef } from "../lib/ecs-js/index.js";
+
+/**
+ * Central script registry for rules-side scripted behaviors.
+ * Scripts are registered by string key and can expose handlers for
+ * a variety of verbs (e.g., spell casts, affix triggers).
+ */
+const REGISTRY = new Map();
+
+export const ScriptVerb = Object.freeze({
+  SpellCast: "spell:cast",
+  AffixOnBeforeHit: "affix:onBeforeHit",
+  AffixOnHit: "affix:onHit",
+  AffixOnDamaged: "affix:onDamaged",
+  AffixPassive: "affix:passive",
+  ItemOnEquip: "item:onEquip",
+  ItemOnUnequip: "item:onUnequip",
+});
+
+/**
+ * Register a script handler map for a given key.
+ * Handlers may be either a function (default verb) or an object of verb → function.
+ * @param {string} key
+ * @param {Record<string, (world: import('../lib/ecs-js').World, ctx: any) => any> | ((world: import('../lib/ecs-js').World, ctx: any) => any)} handlers
+ */
+export function registerScript(key, handlers) {
+  if (!key) return;
+  if (typeof handlers !== "function" && (typeof handlers !== "object" || !handlers)) return;
+  const normalizedKey = String(key);
+  const existing = REGISTRY.get(normalizedKey);
+  if (existing && typeof existing === "object" && typeof handlers === "object") {
+    REGISTRY.set(normalizedKey, { ...existing, ...handlers });
+  } else {
+    REGISTRY.set(normalizedKey, handlers);
+  }
+}
+
+/**
+ * Fetch the handler map for a script key.
+ * @param {string} key
+ */
+export function getScriptHandlers(key) {
+  return REGISTRY.get(String(key));
+}
+
+function normalizeRef(ref) {
+  if (!ref) return { key: "", params: null, inline: null };
+  if (typeof ref === "string") return { key: ref, params: null, inline: null };
+  if (typeof ref === "function") return { key: "", params: null, inline: ref };
+  if (typeof ref === "object") {
+    const key = ref.key ?? ref.ref ?? ref.script ?? "";
+    const params = ref.params ?? null;
+    const inline = typeof ref.fn === "function" ? ref.fn : (typeof ref.handler === "function" ? ref.handler : null);
+    return { key, params, inline };
+  }
+  return { key: "", params: null, inline: null };
+}
+
+function resolveHandler(handlers, verb) {
+  if (!handlers) return null;
+  if (typeof handlers === "function") return handlers;
+  if (verb && typeof handlers[verb] === "function") return handlers[verb];
+  if (typeof handlers.default === "function") return handlers.default;
+  if (typeof handlers.run === "function") return handlers.run;
+  return null;
+}
+
+function mergeParams(target, params) {
+  if (!params) return target;
+  const out = target && typeof target === "object" ? target : {};
+  if (!out.params || typeof out.params !== "object") out.params = {};
+  for (const [k, v] of Object.entries(params)) {
+    if (!(k in out.params)) out.params[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Run a script by key or ScriptRef.
+ * @param {string | {key?:string, ref?:string, params?:any, fn?:Function, handler?:Function}} ref
+ * @param {string} verb
+ * @param {import('../lib/ecs-js').World} world
+ * @param {any} context
+ */
+export function runScript(ref, verb, world, context = {}) {
+  const { key, params, inline } = normalizeRef(ref);
+  const handlerSource = key ? REGISTRY.get(String(key)) : null;
+  const handler = inline || resolveHandler(handlerSource, verb);
+  if (typeof handler !== "function") return;
+  const ctx = context && typeof context === "object" ? context : {};
+  if (!ctx.world) ctx.world = world;
+  mergeParams(ctx, params);
+  try {
+    return handler(world, ctx);
+  } catch (err) {
+    // Swallow script errors to keep deterministic simulation alive
+    console.error?.("Script error", key || "<inline>", verb, err);
+    return undefined;
+  }
+}
+
+/**
+ * Convenience helper that looks up ScriptRef on an entity and executes the handler for the given verb.
+ * @param {import('../lib/ecs-js').World} world
+ * @param {number} entityId
+ * @param {string} verb
+ * @param {any} context
+ */
+export function runEntityScript(world, entityId, verb, context = {}) {
+  if (!world || !(entityId > 0)) return;
+  const ref = world.get(entityId, ScriptRef);
+  if (!ref) return;
+  return runScript(ref, verb, world, { ...context, entityId });
+}
+
+/**
+ * Expose registry for debugging/testing.
+ */
+export function listRegisteredScripts() {
+  return Array.from(REGISTRY.keys());
+}

--- a/src/rules/scripts/spells.js
+++ b/src/rules/scripts/spells.js
@@ -2,94 +2,84 @@
 // Minimal spell script registry and runner (pure rules; deterministic).
 /** @typedef {import('../../lib/ecs-js').World} World */
 
-/**
- * Register built-in spell scripts here. Handlers may mutate the world,
- * spawn projectiles, apply status, or emit semantic events.
- * Signature: (world, actor, spell, intent) => void
- */
-const REGISTRY = Object.create(null);
-
+import { registerScript, runScript, ScriptVerb } from "../scripting.js";
 import { Position } from "../components/Position.js";
 import { NamedIdentity } from "../components/NamedIdentity.js";
 import { Vitality } from "../components/Vitality.js";
 
-// Example: Lightning — auto-target nearest enemy and chain to up to 3 foes.
-/** @param {World} world @param {number} actor @param {{id:string,name:string,manaCost:number,[k:string]:any}} spell @param {{[k:string]:any}} intent */
-REGISTRY['lightning'] = function lightningScript(world, actor, spell, intent) {
-  // Find actor position
-  /** @type {{x:number,y:number}|null} */
-  const apos = /** @type any */ (world.get(actor, Position));
-  if (!apos) return;
+const LIGHTNING_KEY = "lightning";
 
-  const MAX_R = 12; // tiles
-  const CHAIN_MAX = 3;
-  const CHAIN_RADIUS = 8;
+registerScript(LIGHTNING_KEY, {
+  [ScriptVerb.SpellCast]: (world, ctx) => {
+    const actor = ctx?.actor | 0;
+    const spell = ctx?.spell;
+    if (!(actor > 0) || !spell) return;
 
-  // Helper: distance squared
-  const d2 = (x0, y0, x1, y1) => { const dx = x1 - x0, dy = y1 - y0; return dx*dx + dy*dy; };
+    /** @type {{x:number,y:number}|null} */
+    const apos = /** @type any */ (world.get(actor, Position));
+    if (!apos) return;
 
-  // Collect candidate targets (monsters only for now)
-  /** @type {Array<{id:number,x:number,y:number}>} */
-  const candidates = [];
-  for (const [id, p] of world.query(Position)) {
-    if (id === actor) continue;
-    const ni = /** @type any */ (world.get(id, NamedIdentity));
-    if (!ni || ni.identity !== 'monster') continue;
-    const vit = /** @type any */ (world.get(id, Vitality));
-    if (!vit || (vit.hp|0) <= 0) continue;
-    // within max radius
-    if (d2(apos.x, apos.y, p.x, p.y) <= MAX_R*MAX_R) {
-      candidates.push({ id, x: p.x, y: p.y });
-    }
-  }
-  if (!candidates.length) {
-    // Nothing to hit; emit a short self-burst semantic
-    try { world.emit && world.emit('spell:bolt', { actor, targetId: actor, spellId: spell.id, from: {x: apos.x, y: apos.y}, to: {x: apos.x, y: apos.y}, chainIndex: 0 }); } catch {}
-    return;
-  }
+    const MAX_R = 12;
+    const CHAIN_MAX = 3;
+    const CHAIN_RADIUS = 8;
+    const d2 = (x0, y0, x1, y1) => { const dx = x1 - x0, dy = y1 - y0; return dx * dx + dy * dy; };
 
-  // Choose nearest from actor
-  candidates.sort((a,b)=> d2(apos.x,apos.y,a.x,a.y) - d2(apos.x,apos.y,b.x,b.y));
-  const used = new Set();
-  const chain = [];
-  let cur = candidates[0];
-  used.add(cur.id);
-  chain.push(cur);
-
-  // Chain to up to CHAIN_MAX-1 additional targets, nearest to current within CHAIN_RADIUS
-  while (chain.length < CHAIN_MAX) {
-    const last = chain[chain.length - 1];
-    let best = null; let bestD2 = Infinity;
-    for (const c of candidates) {
-      if (used.has(c.id)) continue;
-      const dist2 = d2(last.x, last.y, c.x, c.y);
-      if (dist2 <= CHAIN_RADIUS*CHAIN_RADIUS && dist2 < bestD2) { best = c; bestD2 = dist2; }
-    }
-    if (!best) break;
-    used.add(best.id);
-    chain.push(best);
-  }
-
-  // Apply damage along the chain and emit semantic bolt events for display
-  for (let i=0; i<chain.length; i++) {
-    const segFrom = (i === 0) ? { x: apos.x, y: apos.y } : { x: chain[i-1].x, y: chain[i-1].y };
-    const segTo = { x: chain[i].x, y: chain[i].y };
-    const targetId = chain[i].id;
-    try { world.emit && world.emit('spell:bolt', { actor, targetId, spellId: spell.id, from: segFrom, to: segTo, chainIndex: i }); } catch {}
-
-    // Damage model: base 7 → attenuate per chain
-    const base = 7;
-    const dmg = Math.max(1, Math.round(base * Math.pow(0.7, i)));
-    const vit = /** @type any */ (world.get(targetId, Vitality));
-    if (vit) {
-      vit.hp = Math.max(0, (vit.hp|0) - dmg);
-      try { world.emit && world.emit('damage', { id: targetId, amount: dmg, at: segTo }); } catch {}
-      if ((vit.hp|0) <= 0) {
-        try { world.emit && world.emit('died', { id: targetId, at: segTo }); } catch {}
+    /** @type {Array<{id:number,x:number,y:number}>} */
+    const candidates = [];
+    for (const [id, p] of world.query(Position)) {
+      if (id === actor) continue;
+      const ni = /** @type any */ (world.get(id, NamedIdentity));
+      if (!ni || ni.identity !== "monster") continue;
+      const vit = /** @type any */ (world.get(id, Vitality));
+      if (!vit || (vit.hp | 0) <= 0) continue;
+      if (d2(apos.x, apos.y, p.x, p.y) <= MAX_R * MAX_R) {
+        candidates.push({ id, x: p.x, y: p.y });
       }
     }
-  }
-};
+    if (!candidates.length) {
+      try { world.emit && world.emit("spell:bolt", { actor, targetId: actor, spellId: spell.id, from: { x: apos.x, y: apos.y }, to: { x: apos.x, y: apos.y }, chainIndex: 0 }); } catch {}
+      return;
+    }
+
+    candidates.sort((a, b) => d2(apos.x, apos.y, a.x, a.y) - d2(apos.x, apos.y, b.x, b.y));
+    const used = new Set();
+    const chain = [];
+    let cur = candidates[0];
+    used.add(cur.id);
+    chain.push(cur);
+
+    while (chain.length < CHAIN_MAX) {
+      const last = chain[chain.length - 1];
+      let best = null; let bestD2 = Infinity;
+      for (const c of candidates) {
+        if (used.has(c.id)) continue;
+        const dist2 = d2(last.x, last.y, c.x, c.y);
+        if (dist2 <= CHAIN_RADIUS * CHAIN_RADIUS && dist2 < bestD2) { best = c; bestD2 = dist2; }
+      }
+      if (!best) break;
+      used.add(best.id);
+      chain.push(best);
+    }
+
+    for (let i = 0; i < chain.length; i++) {
+      const segFrom = (i === 0) ? { x: apos.x, y: apos.y } : { x: chain[i - 1].x, y: chain[i - 1].y };
+      const segTo = { x: chain[i].x, y: chain[i].y };
+      const targetId = chain[i].id;
+      try { world.emit && world.emit("spell:bolt", { actor, targetId, spellId: spell.id, from: segFrom, to: segTo, chainIndex: i }); } catch {}
+
+      const base = 7;
+      const dmg = Math.max(1, Math.round(base * Math.pow(0.7, i)));
+      const vit = /** @type any */ (world.get(targetId, Vitality));
+      if (vit) {
+        vit.hp = Math.max(0, (vit.hp | 0) - dmg);
+        try { world.emit && world.emit("damage", { id: targetId, amount: dmg, at: segTo }); } catch {}
+        if ((vit.hp | 0) <= 0) {
+          try { world.emit && world.emit("died", { id: targetId, at: segTo }); } catch {}
+        }
+      }
+    }
+  },
+});
 
 /**
  * Execute a spell script if present.
@@ -99,15 +89,17 @@ REGISTRY['lightning'] = function lightningScript(world, actor, spell, intent) {
  * @param {{ [k:string]: any }} intent
  */
 export function runSpellScript(world, actor, spell, intent) {
-  const key = String(spell?.script || '') || '';
-  const fn = key ? REGISTRY[key] : null;
-  if (typeof fn === 'function') {
-    try { fn(world, actor, spell, intent || {}); } catch {}
-  }
+  const key = String(spell?.script || "") || "";
+  if (!key) return;
+  runScript(key, ScriptVerb.SpellCast, world, { actor, spell, intent: intent || {} });
 }
 
-/** @param {string} key @param {(world:World, actor:number, spell:any, intent:any)=>void} fn */
+/** @param {string} key @param {(world:World, ctx:any)=>void | Record<string,(world:World,ctx:any)=>void>} fn */
 export function registerSpellScript(key, fn) {
-  if (!key || typeof fn !== 'function') return;
-  REGISTRY[String(key)] = fn;
+  if (!key) return;
+  if (typeof fn === "function") {
+    registerScript(key, { [ScriptVerb.SpellCast]: fn });
+  } else if (typeof fn === "object" && fn) {
+    registerScript(key, fn);
+  }
 }

--- a/src/rules/systems/affixTriggerSystem.js
+++ b/src/rules/systems/affixTriggerSystem.js
@@ -5,6 +5,7 @@ import { Equipment } from '../components/Equipment.js';
 import { ItemInfo } from '../components/ItemInfo.js';
 import { AFFIX_DEFS } from '../data/affixes.js';
 import { Vitality } from '../components/Vitality.js';
+import { runScript, ScriptVerb } from '../scripting.js';
 
 function eachAffix(world, entityId, cb) {
   const eq = world.get(entityId, Equipment);
@@ -47,6 +48,10 @@ export function installAffixTriggers(world) {
     const base = { attacker: source, defender: target, weaponId: 0, damage: amount, world };
     const ctxT = makeCtx(world, base);
     // defender affixes with onDamaged
-    eachAffix(world, target, (a) => { if (a.triggers?.includes('onDamaged') && typeof a.script === 'function') a.script(ctxT); });
+    eachAffix(world, target, (a) => {
+      if (a.triggers?.includes('onDamaged') && a.script) {
+        runScript(a.script, ScriptVerb.AffixOnDamaged, world, ctxT);
+      }
+    });
   });
 }

--- a/src/rules/systems/combatSystem.js
+++ b/src/rules/systems/combatSystem.js
@@ -13,6 +13,7 @@ import { BoundingCircle } from '../components/BoundingCircle.js';
 import { Anatomy } from '../components/Anatomy.js';
 import { AFFIX_DEFS } from '../data/affixes.js';
 import { mulberry32, rngInt } from '../../lib/ecs-js/rng.js';
+import { runScript, ScriptVerb } from '../scripting.js';
 
 /** @param {import('../../lib/ecs-js').World} world @param {number} entityId @param {(a:any, slotId:number)=>void} fn */
 function forEachAffix(world, entityId, fn) {
@@ -128,7 +129,11 @@ export function combatSystem(world) {
         // Pre-hit hooks
         const ctx = attachHelpers(world, { attacker, defender, weaponId: weaponId || 0, damage: dmg, world });
         world.emit('beforeHit', ctx);
-    forEachAffix(world, attacker, /** @param {any} a */ (a) => { if (a.triggers?.includes('onBeforeHit') && typeof a.script === 'function') a.script(ctx); });
+        forEachAffix(world, attacker, /** @param {any} a */ (a) => {
+            if (a.triggers?.includes('onBeforeHit') && a.script) {
+                runScript(a.script, ScriptVerb.AffixOnBeforeHit, world, ctx);
+            }
+        });
         // Recompute damage if modified
         let finalDmg = Math.max(0, Math.floor(ctx.damage));
 
@@ -136,12 +141,21 @@ export function combatSystem(world) {
         world.emit('hit', hitCtx);
         let hasVamp = false;
         // Attacker on-hit affixes (e.g., vampiric)
-        forEachAffix(world, attacker, /** @param {any} a */ (a) => { if (a.triggers?.includes('onHit') && typeof a.script === 'function') { a.script(hitCtx); if (a.name && a.name.toLowerCase().includes('vamp')) hasVamp = true; } });
+        forEachAffix(world, attacker, /** @param {any} a */ (a) => {
+            if (a.triggers?.includes('onHit') && a.script) {
+                runScript(a.script, ScriptVerb.AffixOnHit, world, hitCtx);
+                if (a.name && a.name.toLowerCase().includes('vamp')) hasVamp = true;
+            }
+        });
         finalDmg = Math.max(0, Math.floor(hitCtx.damage));
         if (hasVamp) hitCtx.healAttacker(Math.max(1, Math.floor(finalDmg/3)));
         // Defender on-hit reactions (e.g., Thorns)
         const defCtx = attachHelpers(world, { attacker, defender, weaponId: ctx.weaponId || 0, damage: finalDmg, world });
-        forEachAffix(world, defender, /** @param {any} a */ (a) => { if (a.triggers?.includes('onHit') && typeof a.script === 'function') a.script(defCtx); });
+        forEachAffix(world, defender, /** @param {any} a */ (a) => {
+            if (a.triggers?.includes('onHit') && a.script) {
+                runScript(a.script, ScriptVerb.AffixOnHit, world, defCtx);
+            }
+        });
 
         // Invulnerability gate: if defender has 'invulnerable' status active, nullify damage
         const stat = world.get(defender, Status);

--- a/src/rules/systems/equipmentSystem.js
+++ b/src/rules/systems/equipmentSystem.js
@@ -5,6 +5,7 @@
 import { Equipment } from '../components/Equipment.js';
 import { ItemInfo } from '../components/ItemInfo.js';
 import { AFFIX_DEFS } from '../data/affixes.js';
+import { runScript, ScriptVerb } from '../scripting.js';
 
 function emptyDerived() {
   return {
@@ -25,11 +26,11 @@ function applyBonuses(acc, bonuses) {
   if (Number.isFinite(bonuses.critMult)) acc.critMultDerived += bonuses.critMult;
 }
 
-function runAffixPassives(ctx, affixIds) {
+function runAffixPassives(world, ctx, affixIds) {
   for (const aId of affixIds || []) {
     const a = AFFIX_DEFS[aId];
-    if (!a || typeof a.passive !== 'function') continue;
-    a.passive(ctx);
+    if (!a || !a.passive) continue;
+    runScript(a.passive, ScriptVerb.AffixPassive, world, ctx);
   }
 }
 
@@ -52,7 +53,7 @@ export function equipmentSystem(world) {
         itemId,
         world
       };
-      runAffixPassives(ctx, info.affixes);
+      runAffixPassives(world, ctx, info.affixes);
     }
 
     // write back results


### PR DESCRIPTION
## Summary
- add a central scripting registry and verbs for the rules engine
- migrate spell and affix definitions to register handlers through the router
- update combat, equipment, and trigger systems to invoke scripts by key and remove the local ScriptRef component

## Testing
- npm run test:sanity *(fails: missing src/lib/ecs-js submodule in environment)*

------
https://chatgpt.com/codex/tasks/task_e_690d17d57a988333ae38aa4ce27f8d8b