### PR TITLE
Fix touch targeting and ranged ammo handling

### DIFF
--- a/app/input/rulesDispatch.js
+++ b/app/input/rulesDispatch.js
@@ -2,7 +2,7 @@
 // App-owned translation from display/input Actions → rules intents on the ECS world.
 // This file is allowed to import rules and the ECS World (per Separation Manifest).
 
-import { MoveIntent, WaitIntent, DrinkIntent, CastSpellIntent, PickupIntent, EquipIntent, Position, ItemInfo } from "../../src/rules/components/index.js";
+import { MoveIntent, WaitIntent, DrinkIntent, CastSpellIntent, PickupIntent, EquipIntent, Position, ItemInfo, FaceIntent } from "../../src/rules/components/index.js";
 import { UseIntent } from "../../src/rules/components/Intents/UseIntent.js";
 import { RangedAttackIntent } from "../../src/rules/components/Intents/RangedAttackIntent.js";
 import { itemsAt } from "../../src/rules/utils/queries.js";
@@ -42,6 +42,17 @@ export function makeRulesDispatcher(world, getActorId) {
         if (Number.isFinite(x) && Number.isFinite(y)) { intent.x = x; intent.y = y; }
         if (Number.isFinite(vx) && Number.isFinite(vy)) { intent.vx = vx; intent.vy = vy; }
         world?.add?.(actorId, CastSpellIntent, intent);
+        world?.tick?.(1);
+        break;
+      }
+      case "rules.face": {
+        const { dx = null, dy = null, toX = null, toY = null } = action.payload || {};
+        const intent = {};
+        if (Number.isFinite(dx)) intent.dx = dx;
+        if (Number.isFinite(dy)) intent.dy = dy;
+        if (Number.isFinite(toX)) intent.toX = toX;
+        if (Number.isFinite(toY)) intent.toY = toY;
+        world?.add?.(actorId, FaceIntent, intent);
         world?.tick?.(1);
         break;
       }

--- a/app/rules/scheduler.js
+++ b/app/rules/scheduler.js
@@ -16,6 +16,7 @@ import { equipmentSystem } from "../../src/rules/systems/equipmentSystem.js";
 import { waitSystem } from "../../src/rules/systems/waitSystem.js";
 import { castSpellSystem } from "../../src/rules/systems/castSpellSystem.js";
 import { rangedAttackSystem } from "../../src/rules/systems/rangedAttackSystem.js";
+import { faceSystem } from "../../src/rules/systems/faceSystem.js";
 import { aiChaseSystem } from "../../src/rules/systems/aiChaseSystem.js";
 import { movementSystem } from "../../src/rules/systems/movementSystem.js";
 import { combatSystem } from "../../src/rules/systems/combatSystem.js";
@@ -42,6 +43,7 @@ export function configureWorld(world) {
   registerSystem(projectileSystem, 'intents');
   registerSystem(interactionSystem, 'intents');
   registerSystem(castSpellSystem, 'intents');
+  registerSystem(faceSystem, 'intents');
   registerSystem(rangedAttackSystem, 'intents');
   registerSystem(movementSystem, 'intents');
   registerSystem(combatSystem, 'intents');

--- a/src/main/ui/setupUIEventListeners.js
+++ b/src/main/ui/setupUIEventListeners.js
@@ -43,8 +43,8 @@ export function setupUIEventListeners(world, deps) {
   const displayHandler = (action) => {
     switch (action.type) {
       case "display.tapWorld": {
-        const wx = Number(action?.payload?.x);
-        const wy = Number(action?.payload?.y);
+        const wx = (typeof action?.payload?.x === "number") ? action.payload.x : NaN;
+        const wy = (typeof action?.payload?.y === "number") ? action.payload.y : NaN;
         const pe = playerEntity(world);
         if (!pe) break;
         if (Number.isFinite(wx) && Number.isFinite(wy)) {
@@ -76,7 +76,10 @@ export function setupUIEventListeners(world, deps) {
             if (wName && typeof wName.identity === 'string' && wName.identity.startsWith('bow_')) isRanged = true;
           }
 
-          // Facing check: ensure monster is in front arc
+          // Facing + FOV cone check: ensure monster sits within the visible arc
+          const facingComp = world.get(pe.id, Facing) || { x: 1, y: 0 };
+          const baseAngle = Math.atan2(facingComp.y || 0, facingComp.x || 1);
+          const halfFov = Math.PI * 0.75 * 0.5; // match display FOV
           let inFront = false;
           if (tappedMonster) {
             const fx = world.get(pe.id, Facing) || { x: 1, y: 0 };
@@ -86,8 +89,11 @@ export function setupUIEventListeners(world, deps) {
               const dx = tpos.x - ppos.x, dy = tpos.y - ppos.y;
               const len = Math.hypot(dx, dy) || 1;
               const dot = (dx/len) * (fx.x||1) + (dy/len) * (fx.y||0);
-              const CONE_DOT = Math.cos(Math.PI / 10); // ~18°
-              inFront = dot >= CONE_DOT;
+              const CONE_DOT = Math.cos(halfFov);
+              const ang = Math.atan2(dy, dx);
+              let diff = ang - baseAngle;
+              diff = Math.atan2(Math.sin(diff), Math.cos(diff));
+              inFront = dot >= CONE_DOT && Math.abs(diff) <= (halfFov + 1e-3);
             }
           }
 
@@ -95,6 +101,15 @@ export function setupUIEventListeners(world, deps) {
             const handler = resolveRulesDispatcher(world, () => (playerEntity(world)?.id || 0));
             handler({ type: "rules.shootRangedAt", payload: { targetId: tappedMonster } });
             break;
+          }
+
+          if (tappedMonster && isRanged) {
+            const tpos = world.get(tappedMonster, Position);
+            if (tpos) {
+              const handler = resolveRulesDispatcher(world, () => (playerEntity(world)?.id || 0));
+              handler({ type: "rules.face", payload: { toX: tpos.x, toY: tpos.y } });
+              break;
+            }
           }
 
           // Default: move toward tap

--- a/src/rules/components/Intents/FaceIntent.js
+++ b/src/rules/components/Intents/FaceIntent.js
@@ -1,0 +1,9 @@
+import { defineComponent } from "../../../lib/ecs-js/index.js";
+
+// Intent to rotate an actor toward a direction or world-space point.
+export const FaceIntent = defineComponent("FaceIntent", {
+  dx: 0,
+  dy: 0,
+  toX: 0,
+  toY: 0,
+});

--- a/src/rules/components/index.js
+++ b/src/rules/components/index.js
@@ -26,6 +26,7 @@ export { Status } from './Status.js';
 export { Vitality } from './Vitality.js';
 export { Settings } from './Settings.js';
 export { UseIntent } from './Intents/UseIntent.js';
+export { FaceIntent } from './Intents/FaceIntent.js';
 export { DungeonGeometry } from './DungeonGeometry.js';
 export { LightSource } from './LightSource.js';
 export { MonsterSpawner } from './MonsterSpawner.js';

--- a/src/rules/systems/faceSystem.js
+++ b/src/rules/systems/faceSystem.js
@@ -1,0 +1,35 @@
+import { FaceIntent } from "../components/Intents/FaceIntent.js";
+import { Facing } from "../components/Facing.js";
+import { Position } from "../components/Position.js";
+
+const EPS = 1e-5;
+
+/** @param {import("../../lib/ecs-js").World} world */
+export function faceSystem(world) {
+  for (const [actor, intent] of world.query(FaceIntent)) {
+    try {
+      let dx = Number.isFinite(intent.dx) ? intent.dx : 0;
+      let dy = Number.isFinite(intent.dy) ? intent.dy : 0;
+      if (Math.abs(dx) < EPS && Math.abs(dy) < EPS) {
+        const pos = world.get(actor, Position);
+        const tx = Number.isFinite(intent.toX) ? intent.toX : null;
+        const ty = Number.isFinite(intent.toY) ? intent.toY : null;
+        if (pos && tx != null && ty != null) {
+          dx = tx - pos.x;
+          dy = ty - pos.y;
+        }
+      }
+      const mag = Math.hypot(dx, dy);
+      if (mag > EPS) {
+        const dir = { x: dx / mag, y: dy / mag };
+        if (world.has(actor, Facing)) {
+          world.set(actor, Facing, dir);
+        } else {
+          try { world.add(actor, Facing, dir); } catch {}
+        }
+        try { world.emit && world.emit("faced", { id: actor, facing: dir }); } catch {}
+      }
+    } catch {}
+    try { world.remove(actor, FaceIntent); } catch {}
+  }
+}

--- a/src/rules/systems/rangedAttackSystem.js
+++ b/src/rules/systems/rangedAttackSystem.js
@@ -1,5 +1,5 @@
 // src/rules/systems/rangedAttackSystem.js
-// Processes RangedAttackIntent: finds a forward target, applies hit/damage, emits instant VFX.
+// Processes RangedAttackIntent: orients actor, consumes ammo, resolves hits, emits VFX.
 
 import { RangedAttackIntent } from '../components/Intents/RangedAttackIntent.js';
 import { Equipment } from '../components/Equipment.js';
@@ -9,139 +9,257 @@ import { Position } from '../components/Position.js';
 import { Facing } from '../components/Facing.js';
 import { Vitality } from '../components/Vitality.js';
 import { ActiveEffects } from '../components/ActiveEffects.js';
+import { Inventory } from '../components/Inventory.js';
 import { mulberry32, rngInt } from '../../lib/ecs-js/rng.js';
 import { DungeonGeometry } from '../components/DungeonGeometry.js';
 import { GeometryKernel } from '../environment/GeometryKernel.js';
 
+const DEFAULT_RANGE = 12;
+const FOV_ANGLE = Math.PI * 0.75;
+const HALF_FOV = FOV_ANGLE * 0.5;
+const FOV_DOT = Math.cos(HALF_FOV);
+const EPS = 1e-5;
+
 /** @param {import('../../lib/ecs-js').World} world */
 export function rangedAttackSystem(world) {
   for (const [actor, intent] of world.query(RangedAttackIntent)) {
-    // Require equipped bow-like weapon
-    const eq = world.get(actor, Equipment);
-    const weaponId = eq?.weapon || 0;
-    const wName = weaponId ? /** @type any */(world.get(weaponId, NamedIdentity)) : null;
-    const wInfo = weaponId ? /** @type any */(world.get(weaponId, ItemInfo)) : null;
-    const isBow = !!(wName && typeof wName.identity === 'string' && wName.identity.startsWith('bow_'));
-    if (!weaponId || !wInfo || !isBow) { world.remove(actor, RangedAttackIntent); continue; }
+    try {
+      const eq = world.get(actor, Equipment);
+      const weaponId = eq?.weapon || 0;
+      const wName = weaponId ? /** @type any */(world.get(weaponId, NamedIdentity)) : null;
+      const wInfo = weaponId ? /** @type any */(world.get(weaponId, ItemInfo)) : null;
+      const isBow = !!(wName && typeof wName.identity === 'string' && wName.identity.startsWith('bow_'));
+      if (!weaponId || !wInfo || !isBow) continue;
 
-    const apos = world.get(actor, Position);
-    const facing = /** @type any */ (world.get(actor, Facing)) || { x: 1, y: 0 };
-    if (!apos) { world.remove(actor, RangedAttackIntent); continue; }
+      const apos = world.get(actor, Position);
+      if (!apos) continue;
+      const facing = /** @type any */ (world.get(actor, Facing)) || { x: 1, y: 0 };
 
-    const RANGE = 12;
-    const CONE_DOT = Math.cos(Math.PI / 10); // ~18° facing acceptance
-    const d2 = (x0,y0,x1,y1)=>{ const dx=x1-x0, dy=y1-y0; return dx*dx+dy*dy; };
+      const kernel = buildGeometryKernel(world);
 
-    // Build occlusion kernel from DungeonGeometry snapshot
-    let kernel = null;
-    for (const [, geom] of world.query(DungeonGeometry)) { if (geom) { kernel = new GeometryKernel(geom.options || {}); kernel.deserialize(geom); break; } }
+      // Acquire explicit target (tap-target) if one exists and is valid within FOV.
+      let target = resolveExplicitTarget(world, intent, actor, apos, facing, kernel);
 
-    // Targeted shot: validate LOS and facing; otherwise default to impact in facing
-    let target = null;
-    if ((intent.targetId|0) > 0) {
-      const tid = intent.targetId | 0;
-      const p = world.get(tid, Position);
-      const ni = world.get(tid, NamedIdentity);
-      const vit = world.get(tid, Vitality);
-      if (p && ni && ni.identity === 'monster' && vit && (vit.hp|0) > 0) {
-        // Verify in front (facing), and not occluded (distance unconstrained)
-        const ddx = p.x - apos.x, ddy = p.y - apos.y; const dist = Math.hypot(ddx, ddy) || 1;
-        const dot = (ddx / dist) * (facing.x||1) + (ddy / dist) * (facing.y||0);
-        if (dot >= CONE_DOT) {
-          let clear = true;
-          if (kernel) {
-            const ray = kernel.raycastOccl({ x: apos.x, y: apos.y }, { x: ddx, y: ddy }, dist);
-            if (ray && ray.hit && ray.t < dist - 1e-3) clear = false;
-          }
-          if (clear) target = { id: tid, x: p.x, y: p.y, dist2: dist*dist };
-        }
+      // Fallback: auto-acquire the nearest monster within the forward FOV arc.
+      if (!target) {
+        target = acquireForwardTarget(world, actor, apos, facing, kernel);
       }
-    }
-    // Desired aim: target pos if provided; otherwise strict forward centerline from current facing
-    let desired = target ? { x: target.x, y: target.y } : null;
-    if (!desired) {
-      const fmag = Math.hypot(facing.x || 0, facing.y || 0) || 1;
-      const fx = (facing.x || 0) / fmag;
-      const fy = (facing.y || 0) / fmag;
-      desired = { x: apos.x + fx * RANGE, y: apos.y + fy * RANGE };
-    }
 
-    // Clip to occlusion
-    let finalTo = { x: desired.x, y: desired.y };
-    if (kernel) {
-      const dirx = desired.x - apos.x;
-      const diry = desired.y - apos.y;
-      const dist = Math.hypot(dirx, diry) || RANGE;
-      // For forward shots, extend ray long so it properly finds far walls
-      const maxT = target ? dist : Math.max(dist, 64);
-      const ray = kernel.raycastOccl({ x: apos.x, y: apos.y }, { x: dirx, y: diry }, maxT);
-      if (ray && ray.hit) {
-        finalTo = { x: ray.point.x, y: ray.point.y };
+      // Determine aim point for the shot.
+      let desired = target ? { x: target.x, y: target.y } : null;
+      if (!desired && Number.isFinite(intent.toX) && Number.isFinite(intent.toY)) {
+        desired = { x: intent.toX, y: intent.toY };
       }
-    }
+      if (!desired) {
+        const dir = normalizeVec(facing.x || 1, facing.y || 0);
+        desired = {
+          x: apos.x + dir.x * DEFAULT_RANGE,
+          y: apos.y + dir.y * DEFAULT_RANGE,
+        };
+      }
 
-    // Emit shot VFX (display handles style)
-    try { world.emit && world.emit('ranged:shot', { from: { x: apos.x, y: apos.y }, to: finalTo, style: 'flame' }); } catch {}
+      const shotDir = { x: desired.x - apos.x, y: desired.y - apos.y };
+      if (Math.hypot(shotDir.x, shotDir.y) > EPS) {
+        applyFacing(world, actor, shotDir.x, shotDir.y);
+      }
 
-    if (target) {
-      // If occluded path shortened before target, do impact spark and finish (no damage)
-      if ((Math.abs(finalTo.x - target.x) > 1e-3) || (Math.abs(finalTo.y - target.y) > 1e-3)) {
-        world.remove(actor, RangedAttackIntent);
+      const finalTo = clipShotToOcclusion(kernel, apos, desired, target);
+
+      // Consume an arrow when the shot is loosed.
+      const ammoTemplate = consumeArrow(world, actor);
+
+      try { world.emit && world.emit('ranged:shot', { from: { x: apos.x, y: apos.y }, to: finalTo, style: 'flame' }); } catch {}
+
+      if (!target) continue;
+
+      if (isBlockedBeforeTarget(finalTo, target)) {
         continue;
       }
-      // To-hit resolution similar to melee (deterministic RNG)
+
+      const vit = world.get(target.id, Vitality);
+      if (!vit || (vit.hp|0) <= 0) continue;
+
+      const eqTarget = world.get(target.id, Equipment);
       const atkBonus = 1 + (eq?.attackDerived || 0);
-      const defEq = world.get(target.id, Equipment);
-      const armorClass = 10 + (defEq?.defenseDerived || 0);
+      const armorClass = 10 + (eqTarget?.defenseDerived || 0);
       const seed = (world.seed >>> 0) ^ ((world.step|0) * 0x9e3779b9 >>> 0) ^ (actor >>> 0) ^ ((target.id << 16) >>> 0);
-      const r = mulberry32(seed >>> 0);
-      const d20 = rngInt(r, 1, 20);
+      const rng = mulberry32(seed >>> 0);
+      const d20 = rngInt(rng, 1, 20);
       const totalToHit = d20 + atkBonus;
       const isCrit = d20 === 20;
       const isNat1 = d20 === 1;
       if (!isCrit && (isNat1 || totalToHit < armorClass)) {
-        // Miss feedback (display logs/status)
         try { world.emit && world.emit('status', { id: target.id, kind: 'miss', text: 'MISS', source: actor }); } catch {}
-        world.remove(actor, RangedAttackIntent);
+        maybeReturnArrow(world, target.id, ammoTemplate, rng, false);
         continue;
       }
 
-      // Roll bow damage; default to 1d4 if unspecified
       const spec = (typeof wInfo.damageDice === 'string' && wInfo.damageDice) ? wInfo.damageDice : '1d4';
-      const dmg = rollDice(spec, r) + Math.max(0, Math.floor((eq?.attackDerived || 0) / 2));
+      const dmg = rollDice(spec, rng) + Math.max(0, Math.floor((eq?.attackDerived || 0) / 2));
       const finalDmg = Math.max(0, isCrit ? (dmg * 2) : dmg);
 
-      const tv = world.get(target.id, Vitality);
-      if (tv) {
-        tv.hp = Math.max(0, tv.hp - finalDmg);
-        try { world.emit && world.emit('damaged', { target: target.id, amount: finalDmg, source: actor, critical: isCrit }); } catch {}
-        if ((tv.hp|0) <= 0) { try { world.emit && world.emit('died', { id: target.id, killer: actor }); } catch {} }
-        else {
-          // Add a small burning DoT for flaming arrow flavor
-          const ae = /** @type any */ (world.get(target.id, ActiveEffects));
-          const eff = { key: 'burning', turnsLeft: 2, potency: 1 };
-          if (ae && Array.isArray(ae.effects)) ae.effects.push(eff);
-          else { try { world.add(target.id, ActiveEffects, { effects: [eff] }); } catch {} }
-        }
+      vit.hp = Math.max(0, vit.hp - finalDmg);
+      try { world.emit && world.emit('damaged', { target: target.id, amount: finalDmg, source: actor, critical: isCrit }); } catch {}
+      if ((vit.hp|0) <= 0) {
+        try { world.emit && world.emit('died', { id: target.id, killer: actor }); } catch {}
+      } else {
+        const ae = /** @type any */ (world.get(target.id, ActiveEffects));
+        const eff = { key: 'burning', turnsLeft: 2, potency: 1 };
+        if (ae && Array.isArray(ae.effects)) ae.effects.push(eff);
+        else { try { world.add(target.id, ActiveEffects, { effects: [eff] }); } catch {} }
       }
-    } else {
-      // No target: impact spark now handled/scheduled by display via ranged:shot
-    }
 
-    world.remove(actor, RangedAttackIntent);
+      maybeReturnArrow(world, target.id, ammoTemplate, rng, true);
+    } finally {
+      try { world.remove(actor, RangedAttackIntent); } catch {}
+    }
   }
 }
 
-// Dice helpers (copy from combatSystem for consistency)
+function buildGeometryKernel(world) {
+  for (const [, geom] of world.query(DungeonGeometry)) {
+    if (!geom) continue;
+    const kernel = new GeometryKernel(geom.options || {});
+    kernel.deserialize(geom);
+    return kernel;
+  }
+  return null;
+}
+
+function resolveExplicitTarget(world, intent, actor, apos, facing, kernel) {
+  const tid = intent?.targetId | 0;
+  if (!tid) return null;
+  const pos = world.get(tid, Position);
+  const ni = world.get(tid, NamedIdentity);
+  const vit = world.get(tid, Vitality);
+  if (!pos || !ni || ni.identity !== 'monster' || !vit || (vit.hp|0) <= 0) return null;
+
+  const dx = pos.x - apos.x;
+  const dy = pos.y - apos.y;
+  const dist = Math.hypot(dx, dy) || 1;
+  const dot = (dx / dist) * (facing.x || 1) + (dy / dist) * (facing.y || 0);
+  if (dot < FOV_DOT) return null;
+
+  if (kernel) {
+    const ray = kernel.raycastOccl({ x: apos.x, y: apos.y }, { x: dx, y: dy }, dist);
+    if (ray && ray.hit && ray.t < dist - 1e-3) return null;
+  }
+
+  return { id: tid, x: pos.x, y: pos.y, dist2: dist * dist };
+}
+
+function acquireForwardTarget(world, actor, apos, facing, kernel) {
+  let best = null;
+  for (const [id, pos, ni, vit] of world.query(Position, NamedIdentity, Vitality)) {
+    if (id === actor) continue;
+    if (!pos || !ni || ni.identity !== 'monster') continue;
+    if (!vit || (vit.hp|0) <= 0) continue;
+    const dx = pos.x - apos.x;
+    const dy = pos.y - apos.y;
+    const dist = Math.hypot(dx, dy);
+    if (dist <= EPS) continue;
+    const dot = (dx / dist) * (facing.x || 1) + (dy / dist) * (facing.y || 0);
+    if (dot < FOV_DOT) continue;
+    if (kernel) {
+      const ray = kernel.raycastOccl({ x: apos.x, y: apos.y }, { x: dx, y: dy }, dist);
+      if (ray && ray.hit && ray.t < dist - 1e-3) continue;
+    }
+    const dist2 = dist * dist;
+    if (!best || dist2 < best.dist2) {
+      best = { id, x: pos.x, y: pos.y, dist2 };
+    }
+  }
+  return best;
+}
+
+function clipShotToOcclusion(kernel, apos, desired, target) {
+  if (!kernel) return { x: desired.x, y: desired.y };
+  const dirx = desired.x - apos.x;
+  const diry = desired.y - apos.y;
+  const dist = Math.hypot(dirx, diry) || DEFAULT_RANGE;
+  const maxT = target ? dist : Math.max(dist, 64);
+  const ray = kernel.raycastOccl({ x: apos.x, y: apos.y }, { x: dirx, y: diry }, maxT);
+  if (ray && ray.hit) {
+    return { x: ray.point.x, y: ray.point.y };
+  }
+  return { x: desired.x, y: desired.y };
+}
+
+function isBlockedBeforeTarget(finalTo, target) {
+  return (Math.abs(finalTo.x - target.x) > 1e-3) || (Math.abs(finalTo.y - target.y) > 1e-3);
+}
+
+function normalizeVec(x, y) {
+  const mag = Math.hypot(x, y);
+  if (mag <= EPS) return { x: 1, y: 0 };
+  return { x: x / mag, y: y / mag };
+}
+
+function applyFacing(world, actor, dx, dy) {
+  const mag = Math.hypot(dx, dy);
+  if (mag <= EPS) return;
+  const dir = { x: dx / mag, y: dy / mag };
+  if (world.has(actor, Facing)) {
+    world.set(actor, Facing, dir);
+  } else {
+    try { world.add(actor, Facing, dir); } catch {}
+  }
+}
+
+function consumeArrow(world, actor) {
+  const inv = world.get(actor, Inventory);
+  if (!inv || !Array.isArray(inv.items)) return null;
+  for (const itemId of inv.items.slice()) {
+    const ident = world.get(itemId, NamedIdentity);
+    if (!ident || ident.identity !== 'ammo_arrows') continue;
+    const info = world.get(itemId, ItemInfo);
+    if (!info || (info.count|0) <= 0) continue;
+    const template = {
+      identity: ident.identity,
+      name: ident.name || 'Arrows',
+      info: { ...info, count: 1 },
+    };
+    if ((info.count || 1) > 1) {
+      try { world.mutate(itemId, ItemInfo, (rec) => { rec.count = Math.max(0, (rec.count || 1) - 1); }); } catch {}
+    } else {
+      try { world.mutate(actor, Inventory, (rec) => { rec.items = rec.items.filter((id) => id !== itemId); }); } catch {}
+      try { world.destroy(itemId); } catch {}
+    }
+    return template;
+  }
+  return null;
+}
+
+function maybeReturnArrow(world, targetId, template, rng, hit) {
+  if (!template || typeof rng !== 'function' || !hit) return;
+  if (rngInt(rng, 0, 1) !== 1) return;
+  const inv = world.get(targetId, Inventory);
+  const pos = world.get(targetId, Position);
+  if (inv && Array.isArray(inv.items)) {
+    const existing = inv.items.find((id) => (world.get(id, NamedIdentity)?.identity === template.identity));
+    if (existing) {
+      try { world.mutate(existing, ItemInfo, (rec) => { rec.count = (rec.count || 1) + 1; }); } catch {}
+    } else {
+      const newArrow = world.create();
+      try { world.add(newArrow, NamedIdentity, { name: template.name, identity: template.identity }); } catch {}
+      try { world.add(newArrow, ItemInfo, { ...template.info, count: 1 }); } catch {}
+      try { world.mutate(targetId, Inventory, (rec) => { rec.items.push(newArrow); }); } catch {}
+    }
+  } else if (pos) {
+    const newArrow = world.create();
+    try { world.add(newArrow, NamedIdentity, { name: template.name, identity: template.identity }); } catch {}
+    try { world.add(newArrow, ItemInfo, { ...template.info, count: 1 }); } catch {}
+    try { world.add(newArrow, Position, { x: pos.x, y: pos.y }); } catch {}
+  }
+}
+
 /** @param {string} spec @param {() => number} rng */
 function rollDice(spec, rng) {
-  const m = /^\s*(\d+)d(\d+)\s*$/i.exec(String(spec||''));
+  const m = /^\s*(\d+)d(\d+)\s*$/i.exec(String(spec || ''));
   if (!m) return 1;
-  const cStr = m[1] || '1';
-  const sStr = m[2] || '2';
-  const count = Math.max(1, (parseInt(cStr,10)|0));
-  const sides = Math.max(2, (parseInt(sStr,10)|0));
+  const count = Math.max(1, (parseInt(m[1] || '1', 10) | 0));
+  const sides = Math.max(2, (parseInt(m[2] || '2', 10) | 0));
   let sum = 0;
-  for (let i=0;i<count;i++) sum += rngInt(rng, 1, sides);
+  for (let i = 0; i < count; i++) sum += rngInt(rng, 1, sides);
   return sum;
 }


### PR DESCRIPTION
## Summary
- fix tap-to-target logic to validate world coordinates, enforce FOV checks, and queue a facing action when the target is outside the arc
- add a FaceIntent/component pair plus processing system so the dispatcher can rotate actors without movement
- overhaul the ranged attack system to orient shots, consume arrow stacks, auto-acquire forward targets, and return arrows on a hit

## Testing
- npm test *(fails: cannot resolve src/lib/ecs-js/index.js in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f87a39dbc8333ad0e1bd3a7434167)