### PR TITLE
Add demo entry door and shrink player collision radius

### DIFF
--- a/src/main/scene/demoScene.js
+++ b/src/main/scene/demoScene.js
@@ -1,6 +1,9 @@
 import { createFrom } from "../../lib/ecs-js/archetype.js";
 import { playerEntity } from "../../rules/utils/queries.js";
 import { createPlayer } from "../../rules/archetypes/Player.js";
+import { Door } from "../../rules/archetypes/Door.js";
+import { DoorState } from "../../rules/components/DoorState.js";
+import { Collider } from "../../rules/components/Collider.js";
 import { HealthPotion, GoldStack, ArrowsStack } from "../../rules/archetypes/Items.js";
 import { Spawner } from "../../rules/archetypes/Spawner.js";
 import { ActiveEffects } from "../../rules/components/ActiveEffects.js";
@@ -31,6 +34,7 @@ export function populateDemoScene(world) {
   });
 
   ensurePlayer(world, room.center);
+  placeEntryDoor(world, room);
   grantInitialShield(world);
   placeTorch(world, room);
   placeSpellbook(world, room);
@@ -54,6 +58,30 @@ function ensurePlayer(world, center) {
     return;
   }
   createPlayer(world, { x: center.x, y: center.y, name: "Hero" });
+}
+
+function placeEntryDoor(world, room) {
+  const doorX = room.center.x + room.halfWidth;
+  const doorY = room.center.y;
+  let existingDoorId = null;
+  for (const [id, pos] of world.query(Position, DoorState)) {
+    if (!pos) continue;
+    if (Math.abs(pos.x - doorX) < 0.25 && Math.abs(pos.y - doorY) < 0.25) {
+      existingDoorId = id;
+      break;
+    }
+  }
+
+  if (existingDoorId != null) {
+    world.set(existingDoorId, Position, { x: doorX, y: doorY });
+    world.set(existingDoorId, DoorState, { open: false, locked: false });
+    const collider = world.get(existingDoorId, Collider);
+    if (collider) {
+      world.set(existingDoorId, Collider, { ...collider, solid: true, blocksSight: true });
+    }
+    return;
+  }
+  createFrom(world, Door, { x: doorX, y: doorY });
 }
 
 function grantInitialShield(world) {

--- a/src/rules/archetypes/Player.js
+++ b/src/rules/archetypes/Player.js
@@ -22,7 +22,8 @@ export const PlayerArchetype = defineArchetype(
   [Inventory, (p) => ({ capacity: p.capacity ?? 20, weightLimit: p.weightLimit ?? null, items: [] })],
   [NamedIdentity, (p) => ({ name: p.name ?? "Player", identity: p.identity ?? "player" })],
   [Physiology, (p) => ({ sizeClass: p.sizeClass ?? "M", massKg: p.massKg ?? 80 })],
-  [BoundingCircle, (p) => ({ radius: p.radius ?? 0.55 })],
+  // Slightly slimmer default radius so the player can navigate 1-tile corridors.
+  [BoundingCircle, (p) => ({ radius: p.radius ?? 0.45 })],
   [Facing, (p) => {
     const fx = Number.isFinite(p.facing?.x) ? p.facing.x : 1;
     const fy = Number.isFinite(p.facing?.y) ? p.facing.y : 0;
@@ -52,7 +53,7 @@ export function createPlayer(world, params = {}) {
     world.add(id, Inventory, { capacity: params.capacity ?? 20, weightLimit: params.weightLimit ?? null, items: [] });
     world.add(id, NamedIdentity, { name: params.name ?? "Player", identity: params.identity ?? "player" });
     world.add(id, Physiology, { sizeClass: params.sizeClass ?? "M", massKg: params.massKg ?? 80 });
-    world.add(id, BoundingCircle, { radius: params.radius ?? 0.55 });
+    world.add(id, BoundingCircle, { radius: params.radius ?? 0.45 });
     const fx = Number.isFinite(params.facing?.x) ? params.facing.x : 1;
     const fy = Number.isFinite(params.facing?.y) ? params.facing.y : 0;
     const mag = Math.hypot(fx, fy) || 1;


### PR DESCRIPTION
## Summary
- reduce the default player bounding circle radius so 1-tile corridors are traversable
- add and reset a closed door at the demo scene hallway entrance for interaction testing

## Testing
- npm test *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspace/JSHack/src/lib/ecs-js/index.js')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c151c03c8333b798351b35c4ec9a)