### PR TITLE
Add findNearestValidTileAround helper and use it for pet spawn/teleport; add tests

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@
 // rules/ (app owns lifecycle only; no display code here)
 import { World } from "./lib/ecs-js/index.js";            // ECS World
 import { configureWorld } from "../app/rules/scheduler.js";
-import { playerEntity } from "./rules/utils/queries.js";
+import { playerEntity, findNearestValidTileAround } from "./rules/utils/queries.js";
 
 // display/ camera + director utilities (pure display resources)
 import { createCamera, updateCamera, applyCamera } from "./display/camera/controller.js";
@@ -222,9 +222,13 @@ if (!playerEntity(world)) {
   const pe = playerEntity(world);
   if (pe) {
     const ppos = world.get(pe.id, Position);
+    const spawnTile = findNearestValidTileAround(world, ppos, {
+      maxDistance: 1,
+      exclude: [{ x: ppos.x, y: ppos.y }],
+    });
     const petId = world.create();
     world.add(petId, Pet);
-    world.add(petId, Position, { x: ppos.x + 1, y: ppos.y });
+    world.add(petId, Position, spawnTile || { x: ppos.x, y: ppos.y });
     world.add(petId, NamedIdentity, { name: "Kitty", identity: "kitty" });
     world.add(petId, Faction, { key: "pet" });
     world.add(petId, Owner, { ownerId: pe.id });

--- a/src/rules/systems/petFollowSystem.js
+++ b/src/rules/systems/petFollowSystem.js
@@ -10,6 +10,7 @@ import { Inventory } from "../components/Inventory.js";
 import { ItemInfo } from "../components/ItemInfo.js";
 import { NamedIdentity } from "../components/NamedIdentity.js";
 import { MoveIntent } from "../components/Intents/MoveIntent.js";
+import { findNearestValidTileAround } from "../utils/queries.js";
 
 const FOLLOW_DISTANCE = 2;  // start following when farther than this
 const TELEPORT_DISTANCE = 10; // teleport if farther than this
@@ -46,7 +47,11 @@ export function petFollowSystem(world) {
 
     // Teleport if too far (floor transition, etc.)
     if (dist > TELEPORT_DISTANCE) {
-      world.set(id, Position, { x: playerPos.x + 1, y: playerPos.y });
+      const teleportTile = findNearestValidTileAround(world, playerPos, {
+        maxDistance: 1,
+        exclude: [{ x: playerPos.x, y: playerPos.y }],
+      });
+      if (teleportTile) world.set(id, Position, teleportTile);
       continue;
     }
 

--- a/src/rules/utils/queries.js
+++ b/src/rules/utils/queries.js
@@ -1,6 +1,9 @@
 import { Position } from "../components/Position.js";
 import { ItemInfo } from "../components/ItemInfo.js";
 import { Player } from "../components/Player.js";
+import { Collider } from "../components/Collider.js";
+import { Vitality } from "../components/Vitality.js";
+import { isWalkable } from "../environment/dungeon/tileMap.js";
 
 export function itemsAt(world, x, y) {
   const ids = [];
@@ -19,5 +22,52 @@ export function playerEntity(world) {
       return { id, pos: { x: pos.x, y: pos.y } };
     }
   }
+  return null;
+}
+
+/**
+ * Find the nearest valid tile around a source point.
+ * Valid means walkable terrain and no solid/living occupant.
+ *
+ * @param {import('../../lib/ecs-js/index.js').World} world
+ * @param {{x:number, y:number}} source
+ * @param {{
+ *   maxDistance?: number,
+ *   exclude?: Array<{x:number, y:number}>
+ * }} [opts]
+ */
+export function findNearestValidTileAround(world, source, opts = {}) {
+  const maxDistance = Math.max(0, opts.maxDistance ?? 1);
+  const excluded = new Set((opts.exclude || []).map((p) => `${p.x},${p.y}`));
+  const blocked = new Set();
+
+  for (const [id, pos] of world.query(Position)) {
+    const col = world.get(id, Collider);
+    if (col?.solid) blocked.add(`${pos.x},${pos.y}`);
+
+    const vit = world.get(id, Vitality);
+    if (vit && (vit.hp ?? 0) > 0) blocked.add(`${pos.x},${pos.y}`);
+  }
+
+  const candidates = [];
+  for (let dy = -maxDistance; dy <= maxDistance; dy++) {
+    for (let dx = -maxDistance; dx <= maxDistance; dx++) {
+      const x = source.x + dx;
+      const y = source.y + dy;
+      const dist = Math.abs(dx) + Math.abs(dy);
+      candidates.push({ x, y, dist, axisBias: (dx === 0 || dy === 0) ? 0 : 1 });
+    }
+  }
+
+  candidates.sort((a, b) => a.dist - b.dist || a.axisBias - b.axisBias);
+
+  for (const p of candidates) {
+    const key = `${p.x},${p.y}`;
+    if (excluded.has(key)) continue;
+    if (!isWalkable(p.x, p.y)) continue;
+    if (blocked.has(key)) continue;
+    return { x: p.x, y: p.y };
+  }
+
   return null;
 }

--- a/tests/petPlacement.test.mjs
+++ b/tests/petPlacement.test.mjs
@@ -1,0 +1,63 @@
+import { assert, assertEquals } from "jsr:@std/assert";
+import { World } from '../src/lib/ecs-js/index.js';
+import { findNearestValidTileAround } from '../src/rules/utils/queries.js';
+import { petFollowSystem } from '../src/rules/systems/petFollowSystem.js';
+import { loadChunk, clearAll } from '../src/rules/environment/dungeon/tileMap.js';
+import { CHUNK_SIZE, TILE_FLOOR, TILE_WALL } from '../src/rules/environment/dungeon/constants.js';
+import { Position } from '../src/rules/components/Position.js';
+import { Player } from '../src/rules/components/Player.js';
+import { Pet } from '../src/rules/components/Pet.js';
+import { Collider } from '../src/rules/components/Collider.js';
+
+function fillChunk(fill = TILE_FLOOR) {
+  const tiles = new Uint8Array(CHUNK_SIZE * CHUNK_SIZE);
+  tiles.fill(fill);
+  return tiles;
+}
+
+Deno.test('findNearestValidTileAround finds valid spawn near walls', () => {
+  clearAll();
+  const tiles = fillChunk(TILE_WALL);
+  tiles[1 * CHUNK_SIZE + 1] = TILE_FLOOR; // source tile
+  tiles[2 * CHUNK_SIZE + 1] = TILE_FLOOR; // only valid adjacent tile (1,2)
+  loadChunk(0, 0, tiles);
+
+  const world = new World({ seed: 1 });
+  const tile = findNearestValidTileAround(world, { x: 1, y: 1 }, {
+    maxDistance: 1,
+    exclude: [{ x: 1, y: 1 }],
+  });
+
+  assert(tile, 'expected a valid adjacent tile');
+  assertEquals(tile, { x: 1, y: 2 });
+  clearAll();
+});
+
+Deno.test('pet teleport keeps current position when nearby tiles are blocked', () => {
+  clearAll();
+  loadChunk(0, 0, fillChunk(TILE_FLOOR));
+
+  const world = new World({ seed: 2 });
+  const playerId = world.create();
+  world.add(playerId, Player);
+  world.add(playerId, Position, { x: 5, y: 5 });
+
+  const petId = world.create();
+  world.add(petId, Pet);
+  world.add(petId, Position, { x: 20, y: 20 });
+
+  for (let dy = -1; dy <= 1; dy++) {
+    for (let dx = -1; dx <= 1; dx++) {
+      if (dx === 0 && dy === 0) continue;
+      const blocker = world.create();
+      world.add(blocker, Position, { x: 5 + dx, y: 5 + dy });
+      world.add(blocker, Collider, { solid: true, blocksSight: false });
+    }
+  }
+
+  petFollowSystem(world);
+
+  const petPos = world.get(petId, Position);
+  assertEquals(petPos, { x: 20, y: 20 });
+  clearAll();
+});


### PR DESCRIPTION
### Motivation
- Prevent pets from being placed onto non-walkable or occupied tiles by centralizing adjacency/tile validation into a shared helper.
- Avoid forced invalid placement when spawning or teleporting a pet near walls or blocked areas by returning `null` when no valid adjacent tile exists.

### Description
- Add `findNearestValidTileAround` in `src/rules/utils/queries.js` which searches nearby tiles (configurable `maxDistance`) and validates candidates using `isWalkable`, solid `Collider` components, living occupants via `Vitality.hp`, and an optional `exclude` list, returning the nearest valid tile or `null`.
- Use the helper in `src/main.js` for the kitty spawn to choose a safe adjacent tile (excluding the player tile) and fall back to the player position when no valid adjacent tile is found.
- Use the helper in `src/rules/systems/petFollowSystem.js` teleport branch to only teleport pets when a valid nearby tile exists, otherwise keep the pet at its current position.
- Add unit tests in `tests/petPlacement.test.mjs` covering spawn selection near walls and teleport fallback when surrounding tiles are blocked.

### Testing
- Added `tests/petPlacement.test.mjs` which includes tests for spawn selection near walls and teleport fallback, but the tests were not executed in this environment.
- Attempted to run Deno tooling (`deno fmt` / test runner) but the environment does not have `deno` installed, so formatting/testing could not be performed here.
- Changes committed and verified via repository diff/inspection; automated test run should be executed in CI or a Deno-enabled environment to validate the new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4cb4b3388333bca484866f839667)